### PR TITLE
WIP: CloudFront CD

### DIFF
--- a/internals/docker/Dockerfile
+++ b/internals/docker/Dockerfile
@@ -3,6 +3,12 @@ FROM node:10-slim
 ENV KARMA_BROWSER PhantomJS
 RUN apt-get update && apt-get install libpng12-0 bzip2
 
+# Install aws cli for deployment to CloudFront
+RUN apt-get update \
+  && apt-get install -y python-dev python-pip \
+  && pip install --upgrade awscli \
+  && apt-get autoremove -y python-pip
+
 WORKDIR /code
 
 ADD package.json package.json


### PR DESCRIPTION
CloudFront CD requires the aws cli, which currently depends on python... This may not be preferable to netlify.